### PR TITLE
Syntax + API gateway fix

### DIFF
--- a/index.rb
+++ b/index.rb
@@ -2,7 +2,7 @@
 
 require 'json'
 
-puts JSON.generate({
-  :status => 200, 
-  :body   => "Hello from Ruby"
-})
+puts JSON.generate(
+  statusCode: 200,
+  body: 'Hello from Ruby'
+)


### PR DESCRIPTION
- Uses ruby 1.9 hash syntax
- Makes it work with API gateway (statusCode instead of status)